### PR TITLE
chore(deps): migrate to shared renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>jacaudi/renovate-config:base"]
+}

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "semanticCommits": "enabled",
-  "semanticCommitType": "fix",
-  "semanticCommitScope": "deps"
-}


### PR DESCRIPTION
## Summary
- Move config from `renovate.json` to `.github/renovate.json`
- Use shared presets from `jacaudi/renovate-config`

## Presets Used
- `base` - Common settings, GitHub Actions grouping

Generated with [Claude Code](https://claude.com/claude-code)