### PR TITLE
fix(docker-build): use heredoc for metadata output to prevent bash syntax error

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -298,7 +298,13 @@ jobs:
         run: |
           echo "digest=${{ steps.build-single.outputs.digest }}" >> $GITHUB_OUTPUT
           echo "imageid=${{ steps.build-single.outputs.imageid }}" >> $GITHUB_OUTPUT
-          echo "metadata=${{ steps.build-single.outputs.metadata }}" >> $GITHUB_OUTPUT
+
+          # Use heredoc for metadata to safely handle multi-line JSON with special characters
+          {
+            echo "metadata<<METADATA_EOF"
+            echo '${{ steps.build-single.outputs.metadata }}'
+            echo "METADATA_EOF"
+          } >> $GITHUB_OUTPUT
 
           # Compute fully-qualified digest-pinned image reference
           DIGEST="${{ steps.build-single.outputs.digest }}"


### PR DESCRIPTION
## Summary

- Fixes bash syntax error in the `single-output` step caused by multi-line JSON metadata being interpolated directly into the shell script with unescaped double quotes
- Switches to heredoc-based output with single quotes to safely handle the content

## Root Cause

`${{ steps.build-single.outputs.metadata }}` expands to multi-line pretty-printed JSON containing double quotes. When wrapped in `echo "metadata=..."`, the inner quotes break shell parsing. Subsequent lines (the `if [[ ... ]]` block added in #48) then trigger `syntax error near unexpected token '('`.

Fixes #49

## Test plan

- [ ] Verify single-platform docker-build completes without bash syntax errors
- [ ] Verify metadata output is correctly captured in GITHUB_OUTPUT

🤖 Generated with [Claude Code](https://claude.com/claude-code)