### PR TITLE
fix(docker-build): reference build-single outputs directly in job outputs

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -194,9 +194,9 @@ jobs:
       contents: read
       packages: write
     outputs:
-      digest: ${{ steps.single-output.outputs.digest || '' }}
-      imageid: ${{ steps.single-output.outputs.imageid || '' }}
-      metadata: ${{ steps.single-output.outputs.metadata || '' }}
+      digest: ${{ steps.build-single.outputs.digest || '' }}
+      imageid: ${{ steps.build-single.outputs.imageid || '' }}
+      metadata: ${{ steps.build-single.outputs.metadata || '' }}
       image-ref: ${{ steps.single-output.outputs.image-ref || '' }}
       tags: ${{ inputs.tags || steps.meta.outputs.tags }}
       labels: ${{ steps.meta.outputs.labels }}
@@ -296,17 +296,6 @@ jobs:
         id: single-output
         if: needs.validate.outputs.strategy == 'single'
         run: |
-          echo "digest=${{ steps.build-single.outputs.digest }}" >> $GITHUB_OUTPUT
-          echo "imageid=${{ steps.build-single.outputs.imageid }}" >> $GITHUB_OUTPUT
-
-          # Use heredoc for metadata to safely handle multi-line JSON with special characters
-          {
-            echo "metadata<<METADATA_EOF"
-            echo '${{ steps.build-single.outputs.metadata }}'
-            echo "METADATA_EOF"
-          } >> $GITHUB_OUTPUT
-
-          # Compute fully-qualified digest-pinned image reference
           DIGEST="${{ steps.build-single.outputs.digest }}"
           if [[ -n "${DIGEST}" ]]; then
             echo "image-ref=${{ inputs.registry }}/${{ steps.image-name.outputs.name }}@${DIGEST}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

- References `build-single` step outputs directly in the job `outputs:` block instead of passing them through bash
- Eliminates all shell escaping issues — metadata stays in the GitHub Actions expression layer which handles special characters correctly
- Reduces the `single-output` step to only compute `image-ref` (simple string concatenation)

## Root Cause

The metadata JSON from `docker/build-push-action` includes provenance data containing Dockerfile content. When the Dockerfile has `sed` commands with single-quoted patterns, those single quotes break any bash quoting strategy (`echo "..."` or `echo '...'`). The fix avoids bash entirely for metadata.

Fixes #51

## Test plan

- [ ] Verify single-platform docker-build completes without bash syntax errors
- [ ] Verify digest, imageid, and metadata outputs are correctly propagated
- [ ] Verify image-ref output is still computed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)