### PR TITLE
feat(docker-build): add sha-format input for configurable SHA tags

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -84,6 +84,11 @@ on:
         required: false
         type: string
         default: 'ubuntu-24.04-arm'
+      sha-format:
+        description: 'SHA tag format: short (abc1234), long (full SHA), or none (no SHA tag)'
+        required: false
+        type: string
+        default: 'short'
       runs-on:
         description: 'DEPRECATED: Use amd64-runner instead. Runner label for single-arch builds.'
         required: false
@@ -224,6 +229,25 @@ jobs:
           username: ${{ inputs.registry-username || github.actor }}
           password: ${{ secrets.registry-password || github.token }}
 
+      - name: Compute SHA tag config
+        id: sha-tag
+        run: |
+          case "${{ inputs.sha-format }}" in
+            short)
+              echo "tag=type=sha,prefix=" >> $GITHUB_OUTPUT
+              ;;
+            long)
+              echo "tag=type=sha,format=long,prefix=" >> $GITHUB_OUTPUT
+              ;;
+            none)
+              echo "tag=" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "::error::Invalid sha-format: ${{ inputs.sha-format }}. Must be short, long, or none."
+              exit 1
+              ;;
+          esac
+
       - name: Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -235,7 +259,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix=sha-
+            ${{ steps.sha-tag.outputs.tag }}
           labels: |
             ${{ inputs.version && format('org.opencontainers.image.version={0}', inputs.version) || '' }}
 
@@ -367,6 +391,25 @@ jobs:
           username: ${{ inputs.registry-username || github.actor }}
           password: ${{ secrets.registry-password || github.token }}
 
+      - name: Compute SHA tag config
+        id: sha-tag
+        run: |
+          case "${{ inputs.sha-format }}" in
+            short)
+              echo "tag=type=sha,prefix=" >> $GITHUB_OUTPUT
+              ;;
+            long)
+              echo "tag=type=sha,format=long,prefix=" >> $GITHUB_OUTPUT
+              ;;
+            none)
+              echo "tag=" >> $GITHUB_OUTPUT
+              ;;
+            *)
+              echo "::error::Invalid sha-format: ${{ inputs.sha-format }}. Must be short, long, or none."
+              exit 1
+              ;;
+          esac
+
       - name: Docker Metadata
         id: meta
         uses: docker/metadata-action@v5
@@ -378,7 +421,7 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=sha,prefix=sha-
+            ${{ steps.sha-tag.outputs.tag }}
           labels: |
             ${{ inputs.version && format('org.opencontainers.image.version={0}', inputs.version) || '' }}
 


### PR DESCRIPTION
## Summary

- Adds `sha-format` input to control SHA-based tag generation
- **short** (default): bare short SHA tag (e.g., `a1b2c3d`)
- **long**: full commit SHA tag
- **none**: no SHA tag at all
- Removes the legacy `sha-` prefix from default tag generation

### Breaking change

Default SHA tags change from `sha-abc1234` to `abc1234`. Callers relying on the `sha-` prefix should update their workflows.

Closes #53

## Test plan

- [ ] Verify default `sha-format` produces bare short SHA tags (no `sha-` prefix)
- [ ] Verify `sha-format: long` produces full SHA tags
- [ ] Verify `sha-format: none` omits SHA tags entirely
- [ ] Verify both single-platform and multi-platform builds respect the setting

🤖 Generated with [Claude Code](https://claude.com/claude-code)