### PR TITLE
feat(test): add setup-command input for pre-test setup steps (#56)

### DIFF
--- a/.github/workflows/ci-cd-unified.yml
+++ b/.github/workflows/ci-cd-unified.yml
@@ -76,6 +76,11 @@ on:
         required: false
         type: string
         default: ''
+      setup-command:
+        description: 'Command(s) to run after dependency install but before tests (runs from repo root)'
+        required: false
+        type: string
+        default: ''
 
       # Semantic release configuration
       run-release:
@@ -172,6 +177,7 @@ jobs:
     with:
       test-framework: ${{ inputs.test-framework }}
       test-command: ${{ inputs.test-command }}
+      setup-command: ${{ inputs.setup-command }}
       runs-on: ${{ inputs.runs-on }}
 
   # ===========================================================================

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -59,6 +59,11 @@ on:
         required: false
         type: boolean
         default: true
+      setup-command:
+        description: 'Command(s) to run after dependency install but before tests (runs from repo root, not working-directory)'
+        required: false
+        type: string
+        default: ''
       timeout-minutes:
         description: 'Timeout for test execution in minutes'
         required: false
@@ -200,6 +205,14 @@ jobs:
       - name: Install Bun dependencies
         if: steps.detect.outputs.framework == 'bun' && inputs.install-dependencies
         run: bun install
+
+      # Run setup commands (from repo root, not working-directory)
+      - name: Run Setup Commands
+        if: inputs.setup-command != ''
+        working-directory: .
+        run: |
+          echo "Running setup commands..."
+          ${{ inputs.setup-command }}
 
       # Run tests
       - name: Run Tests


### PR DESCRIPTION
Add a `setup-command` input to the reusable test workflow that runs
arbitrary shell commands after dependency install but before test
execution. The step runs from the repo root (not working-directory),
enabling cross-directory operations like copying embedded files for
Go projects using //go:embed.

Also adds the input passthrough in ci-cd-unified.yml.

Closes #56

https://claude.ai/code/session_01MiXvEK5dk8vRmzJwV2hCkE