### PR TITLE
fix: commit changelog file back to repo

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -260,6 +260,7 @@ jobs:
           steps.release.outputs.new-release-published == 'true' &&
           inputs.changelog-file != '' &&
           !inputs.dry-run
+        continue-on-error: true
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"


### PR DESCRIPTION
## Summary

Closes #73

- **Forward `changelog-file`, `prepend`, and `config-file` inputs** to `go-semantic-release/action@v1` — these were accepted by the workflow but never passed to the action (dead code in the args builder step)
- **Add `prepend` input** (boolean, default `true`) for cumulative changelogs with newest entries at top
- **Add "Commit changelog" step** that commits and pushes the generated changelog file back to the repo after a successful release, with `[skip ci]` to prevent infinite loops
- **Remove dead `Build semantic-release arguments` step** whose output (`steps.args.outputs.args`) was never consumed

## Test Plan

- [ ] Consumer repo (e.g., `nextdns-operator`) with `changelog-file: CHANGELOG.md` triggers a release
- [ ] Verify the changelog file appears in the repo after release
- [ ] Verify `[skip ci]` prevents re-triggering CI
- [ ] Verify dry-run mode does NOT commit anything
- [ ] Verify no commit is made when no release is published
- [ ] Verify `continue-on-error: true` allows the release to succeed even if changelog push fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)