### PR TITLE
fix(container-build): namespace digest artifacts by image-name

### DIFF
--- a/.github/workflows/component-container-build.yml
+++ b/.github/workflows/component-container-build.yml
@@ -182,6 +182,17 @@ jobs:
             echo "name=${{ github.repository }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Compute image slug
+        # Slug used to namespace the digest artifact name so a single workflow
+        # run can build multiple images (e.g. an app + a sidecar) without
+        # artifact-name collisions on the digest-* artifacts. `/` is illegal
+        # in artifact names, so replace it with `-`.
+        id: image-slug
+        run: |
+          SLUG="${{ steps.image-name.outputs.name }}"
+          SLUG="${SLUG//\//-}"
+          echo "value=${SLUG}" >> $GITHUB_OUTPUT
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
@@ -236,7 +247,7 @@ jobs:
         if: inputs.push
         uses: actions/upload-artifact@v7
         with:
-          name: digest-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          name: digest-${{ steps.image-slug.outputs.value }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
           retention-days: 1
 
@@ -264,11 +275,20 @@ jobs:
             echo "name=${{ github.repository }}" >> $GITHUB_OUTPUT
           fi
 
+      - name: Compute image slug
+        # Must match the slug used by the build job's upload step so the
+        # download pattern selects only this image's digest artifacts.
+        id: image-slug
+        run: |
+          SLUG="${{ steps.image-name.outputs.name }}"
+          SLUG="${SLUG//\//-}"
+          echo "value=${SLUG}" >> $GITHUB_OUTPUT
+
       - name: Download digests
         uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
-          pattern: digest-*
+          pattern: digest-${{ steps.image-slug.outputs.value }}-*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

When a single workflow run invokes `component-container-build.yml` twice (or more) for different images (e.g. an app + a sidecar), the artifact names `digest-amd64` / `digest-arm64` **collide**. `actions/download-artifact@v8` returns the most recent artifact for a given name, so the merge job picks up the wrong image's per-arch digest, and `docker buildx imagetools create` fails with `<image>@<digest>: not found` because the digest exists in the other image's repo.

This bit jacaudi/dras's v2.7.1 release on 2026-05-02:

```
container-renderer / Build (linux/arm64)        ✅
container-renderer / Build (linux/amd64)        ✅
container-renderer / Create Multi-arch Manifest ❌
  Found digest for arm64: sha256:1465e7fd…   ← actually the dras arm64 digest
  ERROR: ghcr.io/jacaudi/dras-renderer@sha256:1465…: not found
```

The renderer's arm64 digest never made it into the manifest because the merge job downloaded the dras arm64 artifact (uploaded later, hence "most recent"). `ghcr.io/jacaudi/dras-renderer:v2.7.1` was never tagged. The dras manifest succeeded by timing luck — its merge job ran before the renderer's later artifacts overwrote.

## Fix

Namespace the digest artifact name with a slug derived from `inputs.image-name` (`/` → `-` since `/` is illegal in artifact names). Both upload (build job) and download (merge job) compute the same slug and stay paired.

## Backward compatibility

Consumers don't see these artifact names — they're internal to the reusable workflow's build → merge handoff. No input/output schema changes. Patch-bump-safe.

## Related

- Issue #89 — component-helm-validate proposal (separate scope, this PR is just the container-build fix).
- jacaudi/dras#97 — the consumer that hit this bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)