### PR TITLE
fix(container-build): use _ separator in digest artifact name to prevent prefix-glob collisions

### DIFF
--- a/.github/workflows/component-container-build.yml
+++ b/.github/workflows/component-container-build.yml
@@ -247,7 +247,14 @@ jobs:
         if: inputs.push
         uses: actions/upload-artifact@v7
         with:
-          name: digest-${{ steps.image-slug.outputs.value }}-${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
+          # Use `_` (not `-`) between the slug and the arch token so the
+          # merge job's glob pattern (`digest-<slug>_*`) only matches THIS
+          # image's pair. Using `-` here would let `dras` match `dras-renderer`
+          # (one slug being a prefix of another) and merge-multiple would
+          # silently overwrite the digest files. Underscore is safe because
+          # `/` in image names is already rewritten to `-` in the slug, and
+          # `_` is not a valid character in OCI image names.
+          name: digest-${{ steps.image-slug.outputs.value }}_${{ matrix.platform == 'linux/amd64' && 'amd64' || 'arm64' }}
           path: /tmp/digests/*
           retention-days: 1
 
@@ -288,7 +295,9 @@ jobs:
         uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
-          pattern: digest-${{ steps.image-slug.outputs.value }}-*
+          # `_` separator (see Upload digest comment) prevents prefix-glob
+          # collisions when one image's slug is a prefix of another's.
+          pattern: digest-${{ steps.image-slug.outputs.value }}_*
           merge-multiple: true
 
       - name: Set up Docker Buildx


### PR DESCRIPTION
## Summary

Follow-up to #90. The previous fix namespaced digest artifacts as `digest-<slug>-<arch>`. That works when no two image slugs share a prefix, but **breaks when one slug is a prefix of another** — the merge job's glob pattern `digest-<slug>-*` matches the longer-prefixed sibling's artifacts too, and `merge-multiple: true` silently overwrites the per-arch digest files.

## Validated in production today

`jacaudi/dras` v2.7.1 re-cut on 2026-05-02 (post-merge of jacaudi/dras#100, which bumped to v0.20.2):

| Job | Result | Why |
|---|---|---|
| `container-renderer / Create Multi-arch Manifest` | ✅ | Slug `jacaudi-dras-renderer` is more specific; pattern `digest-jacaudi-dras-renderer-*` doesn't match the `dras` sibling. |
| `container-dras / Create Multi-arch Manifest` | ❌ | Slug `jacaudi-dras` is a prefix of `jacaudi-dras-renderer`; pattern `digest-jacaudi-dras-*` matches **all four** artifacts. The arm64 digest file ended up holding the renderer's arm64 digest, which doesn't exist in the `dras` repo → `not found` error. |

Per-run artifact listing confirmed the four artifacts and the prefix-glob match:

```
digest-jacaudi-dras-amd64
digest-jacaudi-dras-arm64
digest-jacaudi-dras-renderer-amd64    ← also matched by pattern `digest-jacaudi-dras-*`
digest-jacaudi-dras-renderer-arm64    ← also matched by pattern `digest-jacaudi-dras-*`
```

## Fix

Use `_` between the slug and the arch token:

| Before | After |
|---|---|
| `digest-jacaudi-dras-arm64` | `digest-jacaudi-dras_arm64` |
| `digest-jacaudi-dras-renderer-arm64` | `digest-jacaudi-dras-renderer_arm64` |
| Pattern: `digest-jacaudi-dras-*` (matches both) | Pattern: `digest-jacaudi-dras_*` (matches only dras) |

`_` is safe because `/` in image names is already rewritten to `-` in the slug, and `_` is not a valid character in OCI image names. So no slug can ever contain `_`, and the pattern is unambiguous.

## Backward compatibility

Internal artifact names; consumers don't see them. **Patch-bump-safe** (suggest v0.20.3).

## Related

- #90 — original namespacing PR (this fix completes it).
- jacaudi/dras#100 — consumer that exposed the prefix-glob edge case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)