### PR TITLE
fix(semantic-release): resolve app git identity from token outputs, not /users API

### DIFF
--- a/.github/workflows/component-semantic-release.yml
+++ b/.github/workflows/component-semantic-release.yml
@@ -156,31 +156,36 @@ jobs:
 
       - name: Resolve git identity
         id: git-identity
+        # Use the outputs that actions/create-github-app-token@v2 already
+        # exposes (`app-slug` and `installation-id`). The earlier approach
+        # of querying `gh api /users/<slug>[bot]` for the bot user-id often
+        # fails because an app installation token doesn't carry the
+        # `read:user` scope that the /users endpoint requires for some bot
+        # accounts — even though the token itself is valid (commits push,
+        # tags get created, downstream workflows fire). The fallback then
+        # silently authored release commits as `github-actions[bot]` even
+        # when the underlying token was the app's.
+        #
+        # `installation-id+app-slug[bot]@users.noreply.github.com` is the
+        # canonical noreply email format for app commits (per GitHub's own
+        # docs) and requires no extra API lookup.
         run: |
           if [[ "${{ steps.token.outputs.token-type }}" == "app" ]]; then
-            APP_SLUG=$(gh api /app --jq '.slug' || echo "")
-            if [[ -n "${APP_SLUG}" ]]; then
-              APP_ID=$(gh api "/users/${APP_SLUG}[bot]" --jq '.id' || echo "")
-              if [[ -n "${APP_ID}" ]]; then
-                echo "name=${APP_SLUG}[bot]" >> $GITHUB_OUTPUT
-                echo "email=${APP_ID}+${APP_SLUG}[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
-                echo "Resolved git identity: ${APP_SLUG}[bot] (${APP_ID})"
-              else
-                echo "name=github-actions[bot]" >> $GITHUB_OUTPUT
-                echo "email=github-actions[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
-                echo "Could not resolve app user ID, falling back to github-actions[bot]"
-              fi
+            APP_SLUG="${{ steps.app-token.outputs.app-slug }}"
+            INSTALLATION_ID="${{ steps.app-token.outputs.installation-id }}"
+            if [[ -n "${APP_SLUG}" && -n "${INSTALLATION_ID}" ]]; then
+              echo "name=${APP_SLUG}[bot]" >> $GITHUB_OUTPUT
+              echo "email=${INSTALLATION_ID}+${APP_SLUG}[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
+              echo "Resolved git identity: ${APP_SLUG}[bot] (installation ${INSTALLATION_ID})"
             else
               echo "name=github-actions[bot]" >> $GITHUB_OUTPUT
               echo "email=github-actions[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
-              echo "Could not resolve app slug, falling back to github-actions[bot]"
+              echo "Could not resolve app-slug or installation-id outputs from create-github-app-token; falling back to github-actions[bot]"
             fi
           else
             echo "name=github-actions[bot]" >> $GITHUB_OUTPUT
             echo "email=github-actions[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
           fi
-        env:
-          GH_TOKEN: ${{ steps.token.outputs.token }}
 
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

When `use-github-app: true` is set and the app token is created successfully, the release commit's `Author:` and `Committer:` headers fall back to `github-actions[bot]` instead of the actual app's bot account.

Symptom observed in jacaudi/dras's v2.7.1 release on 2026-05-02 (run [25260939180](https://github.com/jacaudi/dras/actions/runs/25260939180)) — the release-job log shows:

```
Using GitHub App token (will trigger downstream workflows)         ← app-token created OK
Could not resolve app user ID, falling back to github-actions[bot] ← identity lookup failed
```

The actual `release: v2.7.1 [skip ci]` commit on `main` is authored by `github-actions[bot]` even though the wall-e-one app DID create the token (downstream container/helm-publish jobs fired correctly, which only happens with the app token, not GITHUB_TOKEN).

## Root cause

The current logic resolves git identity by querying `gh api "/users/${APP_SLUG}[bot]"` for the bot's numeric user-id. An app installation token doesn't carry the `read:user` scope that endpoint requires for some bot accounts, even though the same token is valid for everything else (push, tag, trigger). The lookup returns empty, the fallback in the inner `else` branch fires, and the workflow silently writes the wrong identity.

## Fix

`actions/create-github-app-token@v2` already exposes `app-slug` and `installation-id` outputs. GitHub's own [best-practices doc](https://docs.github.com/en/apps/creating-github-apps/writing-code-for-a-github-app/best-practices-for-creating-a-github-app) recommends building the noreply email as `<installation-id>+<app-slug>[bot]@users.noreply.github.com`, no API lookup required. Switching to that form:

```yaml
APP_SLUG="${{ steps.app-token.outputs.app-slug }}"
INSTALLATION_ID="${{ steps.app-token.outputs.installation-id }}"
echo "name=${APP_SLUG}[bot]" >> $GITHUB_OUTPUT
echo "email=${INSTALLATION_ID}+${APP_SLUG}[bot]@users.noreply.github.com" >> $GITHUB_OUTPUT
```

Removed the now-dead `GH_TOKEN` env on this step (no API call to authenticate against).

## Backward compatibility

Email format change: from `<bot-user-id>+<app-slug>[bot]@…` to `<installation-id>+<app-slug>[bot]@…`. Both are GitHub-recognized noreply formats; the GitHub UI shows the bot account either way. Past commits aren't affected. Patch-bump-safe (suggest v0.20.4).

## Test plan

After merge + release, jacaudi/dras's next release commit should be authored by `wall-e-one[bot]` instead of `github-actions[bot]`. Verify with `git log --pretty=format:'%h %an %s' main` after the next ci-cd.yml run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)